### PR TITLE
Input v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 FetchContent_Declare(
 		vstl
 		GIT_REPOSITORY https://github.com/magistermaks/lib-vstl
-		GIT_TAG v3.1
+		GIT_TAG v3.2
 )
 
 FetchContent_Declare(

--- a/src/input/debug.cpp
+++ b/src/input/debug.cpp
@@ -65,11 +65,11 @@ InputResult DebugInputListener::onEvent(const InputEvent& any) {
 	}
 
 	if (const auto* event = any.as<CloseEvent>()) {
-		printf("DEBUG: CloseEvent {x=%d, y=%d}\n", (int) event->x, (int) event->y);
+		printf("DEBUG: CloseEvent {}\n");
 	}
 
 	if (const auto* event = any.as<ResizeEvent>()) {
-		printf("DEBUG: ResizeEvent {width=%d, height=%d, x=%d, y=%d}\n", event->width, event->height, (int) event->x, (int) event->y);
+		printf("DEBUG: ResizeEvent {width=%d, height=%d}\n", event->width, event->height);
 	}
 
 	if (const auto* event = any.as<MouseEvent>()) {

--- a/src/input/event.cpp
+++ b/src/input/event.cpp
@@ -1,9 +1,0 @@
-
-#include "event.hpp"
-
-/*
- * InputEvent
- */
-
-InputEvent::InputEvent(double x, double y)
-: x(x), y(y) {}

--- a/src/input/event.hpp
+++ b/src/input/event.hpp
@@ -19,6 +19,7 @@ class InputEvent {
 			UNICODE,  ///< UnicodeEvent
 			CLOSE,    ///< CloseEvent
 			RESIZE,   ///< ResizeEvent
+			FRAME,    ///< FrameEvent
 		};
 
 		/**

--- a/src/input/event.hpp
+++ b/src/input/event.hpp
@@ -42,9 +42,6 @@ class InputEvent {
 
 	public:
 
-		double x;
-		double y;
-
-		InputEvent(double x, double y);
+		InputEvent() = default;
 
 };

--- a/src/input/event/close.cpp
+++ b/src/input/event/close.cpp
@@ -9,9 +9,6 @@ InputEvent::Type CloseEvent::getType() const {
 	return CloseEvent::type;
 }
 
-CloseEvent::CloseEvent(double x, double y)
-: InputEvent(x, y) {}
-
 void CloseEvent::abort() const {
 	this->abort_flag = true;
 }

--- a/src/input/event/close.hpp
+++ b/src/input/event/close.hpp
@@ -20,7 +20,7 @@ class CloseEvent : public InputEvent {
 
 	public:
 
-		CloseEvent(double x, double y);
+		CloseEvent() = default;
 
 		/**
 		 * Abort the automatic window closing,

--- a/src/input/event/coded.cpp
+++ b/src/input/event/coded.cpp
@@ -6,7 +6,7 @@
  */
 
 CodedEvent::CodedEvent(int action, int mods, double x, double y)
-: InputEvent(x, y), action(action), mods(mods) {}
+: PositionedEvent(x, y), action(action), mods(mods) {}
 
 bool CodedEvent::isPressEvent() const {
 	return action == GLFW_PRESS;

--- a/src/input/event/coded.hpp
+++ b/src/input/event/coded.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "input/event.hpp"
+#include "positioned.hpp"
 
 /**
  * Base class shared by keyboard and mouse button input events
  */
-class CodedEvent : public InputEvent {
+class CodedEvent : public PositionedEvent {
 
 	public:
 

--- a/src/input/event/frame.cpp
+++ b/src/input/event/frame.cpp
@@ -1,0 +1,18 @@
+
+#include "frame.hpp"
+
+/*
+ * FrameEvent
+ */
+
+InputEvent::Type FrameEvent::getType() const {
+	return FrameEvent::type;
+}
+
+void FrameEvent::capture() const {
+	this->capture_flag = true;
+}
+
+void FrameEvent::close() const {
+	close_flag = true;
+}

--- a/src/input/event/frame.hpp
+++ b/src/input/event/frame.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "input/event.hpp"
+
+/**
+ * Event emitted each frame, used to gain permission to control the window
+ */
+class FrameEvent : public InputEvent {
+
+	private:
+
+		friend class Window;
+		mutable bool capture_flag : 1 = false;
+		mutable bool close_flag : 1 = false;
+
+	public:
+
+		static constexpr Type type = InputEvent::FRAME;
+
+		Type getType() const override;
+
+	public:
+
+		FrameEvent() = default;
+
+		/**
+		 * Hide the mouse and capture it within the window,
+		 * after the event is handled the mouse's state will be updated to match the state of the value set in the event
+		 * By default the mouse will be un-captured, to capture effectively capture() must be called on each event received.
+		 */
+		void capture() const;
+
+		/**
+		 * Break the render loop and close the program window,
+		 * if you aborted the CloseEvent this is how you can later close the window yourself.
+		 * By default this flag is set to NOT close the window.
+		 */
+		 void close() const;
+
+};

--- a/src/input/event/mouse.cpp
+++ b/src/input/event/mouse.cpp
@@ -10,7 +10,7 @@ InputEvent::Type MouseEvent::getType() const {
 }
 
 MouseEvent::MouseEvent(double x, double y)
-: InputEvent(x, y) {}
+: PositionedEvent(x, y) {}
 
 void MouseEvent::capture() const {
 	this->capture_flag = true;

--- a/src/input/event/mouse.cpp
+++ b/src/input/event/mouse.cpp
@@ -11,7 +11,3 @@ InputEvent::Type MouseEvent::getType() const {
 
 MouseEvent::MouseEvent(double x, double y)
 : PositionedEvent(x, y) {}
-
-void MouseEvent::capture() const {
-	this->capture_flag = true;
-}

--- a/src/input/event/mouse.hpp
+++ b/src/input/event/mouse.hpp
@@ -7,11 +7,6 @@
  */
 class MouseEvent : public PositionedEvent {
 
-	private:
-
-		friend class Window;
-		mutable bool capture_flag = false;
-
 	public:
 
 		static constexpr Type type = InputEvent::MOUSE;
@@ -21,12 +16,5 @@ class MouseEvent : public PositionedEvent {
 	public:
 
 		MouseEvent(double x, double y);
-
-		/**
-		 * Hide the mouse and capture it within the window,
-		 * after the event is handled the mouse's state will be updated to match the state of the value set in the event
-		 * By default the mouse will be un-capture, to capture effectively capture() must be called on each event received.
-		 */
-		void capture() const;
 
 };

--- a/src/input/event/mouse.hpp
+++ b/src/input/event/mouse.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "input/event.hpp"
+#include "positioned.hpp"
 
 /**
  * Mouse cursor movement input event
  */
-class MouseEvent : public InputEvent {
+class MouseEvent : public PositionedEvent {
 
 	private:
 

--- a/src/input/event/positioned.cpp
+++ b/src/input/event/positioned.cpp
@@ -7,3 +7,7 @@
 
 PositionedEvent::PositionedEvent(double x, double y)
 : x(x), y(y) {}
+
+glm::vec2 PositionedEvent::getMouse() const {
+	return {x, y};
+}

--- a/src/input/event/positioned.cpp
+++ b/src/input/event/positioned.cpp
@@ -1,0 +1,9 @@
+
+#include "positioned.hpp"
+
+/*
+ * PositionedEvent
+ */
+
+PositionedEvent::PositionedEvent(double x, double y)
+: x(x), y(y) {}

--- a/src/input/event/positioned.hpp
+++ b/src/input/event/positioned.hpp
@@ -14,4 +14,7 @@ class PositionedEvent : public InputEvent {
 
 		PositionedEvent(double x, double y);
 
+		/// Get mouse position as a glm::vec2 vector
+		glm::vec2 getMouse() const;
+
 };

--- a/src/input/event/positioned.hpp
+++ b/src/input/event/positioned.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "input/event.hpp"
+
+/**
+ * Base class shared by all events that contain mouse position information
+ */
+class PositionedEvent : public InputEvent {
+
+	public:
+
+		double x;
+		double y;
+
+		PositionedEvent(double x, double y);
+
+};

--- a/src/input/event/resize.cpp
+++ b/src/input/event/resize.cpp
@@ -9,5 +9,5 @@ InputEvent::Type ResizeEvent::getType() const {
 	return ResizeEvent::type;
 }
 
-ResizeEvent::ResizeEvent(int width, int height, double x, double y)
-: InputEvent(x, y), width(width), height(height) {}
+ResizeEvent::ResizeEvent(int width, int height)
+: width(width), height(height) {}

--- a/src/input/event/resize.hpp
+++ b/src/input/event/resize.hpp
@@ -18,6 +18,6 @@ class ResizeEvent : public InputEvent {
 		int width;
 		int height;
 
-		ResizeEvent(int width, int height, double x, double y);
+		ResizeEvent(int width, int height);
 
 };

--- a/src/input/event/scroll.cpp
+++ b/src/input/event/scroll.cpp
@@ -11,3 +11,7 @@ InputEvent::Type ScrollEvent::getType() const {
 
 ScrollEvent::ScrollEvent(double horizontal, double vertical, double x, double y)
 : PositionedEvent(x, y), horizontal(horizontal), vertical(vertical) {}
+
+glm::vec2 ScrollEvent::getScroll() const {
+	return {horizontal, vertical};
+}

--- a/src/input/event/scroll.cpp
+++ b/src/input/event/scroll.cpp
@@ -10,4 +10,4 @@ InputEvent::Type ScrollEvent::getType() const {
 }
 
 ScrollEvent::ScrollEvent(double horizontal, double vertical, double x, double y)
-: InputEvent(x, y), horizontal(horizontal), vertical(vertical) {}
+: PositionedEvent(x, y), horizontal(horizontal), vertical(vertical) {}

--- a/src/input/event/scroll.hpp
+++ b/src/input/event/scroll.hpp
@@ -20,4 +20,7 @@ class ScrollEvent : public PositionedEvent {
 
 		ScrollEvent(double horizontal, double vertical, double x, double y);
 
+		/// Get mouse scroll amount as a glm::vec2 vector
+		glm::vec2 getScroll() const;
+
 };

--- a/src/input/event/scroll.hpp
+++ b/src/input/event/scroll.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "input/event.hpp"
+#include "positioned.hpp"
 
 /**
  * Mouse wheel scroll input event
  */
-class ScrollEvent : public InputEvent {
+class ScrollEvent : public PositionedEvent {
 
 	public:
 

--- a/src/input/event/unicode.cpp
+++ b/src/input/event/unicode.cpp
@@ -10,4 +10,4 @@ InputEvent::Type UnicodeEvent::getType() const {
 }
 
 UnicodeEvent::UnicodeEvent(uint32_t unicode, double x, double y)
-: InputEvent(x, y), unicode(unicode) {}
+: PositionedEvent(x, y), unicode(unicode) {}

--- a/src/input/event/unicode.hpp
+++ b/src/input/event/unicode.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "input/event.hpp"
+#include "positioned.hpp"
 
 /**
  * Text input event, don't use for generic keyboard controls
  * @see KeyboardEvent
  */
-class UnicodeEvent : public InputEvent {
+class UnicodeEvent : public PositionedEvent {
 
 	public:
 

--- a/src/input/input.hpp
+++ b/src/input/input.hpp
@@ -12,3 +12,4 @@
 #include "event/unicode.hpp"
 #include "event/close.hpp"
 #include "event/resize.hpp"
+#include "event/frame.hpp"

--- a/src/render/window.cpp
+++ b/src/render/window.cpp
@@ -38,6 +38,29 @@ std::unique_ptr<Window> WindowSystem::open(uint32_t w, uint32_t h, const std::st
 }
 
 /*
+ * InputContext
+ */
+
+InputContext::InputContext(const Window& window) {
+	this->handle = window.getHandle();
+}
+
+bool InputContext::isKeyPressed(int key) const {
+	return glfwGetKey(handle, key) == GLFW_PRESS;
+}
+
+bool InputContext::isButtonPressed(int button) const {
+	return glfwGetMouseButton(handle, button) == GLFW_PRESS;
+}
+
+glm::vec2 InputContext::getCursorPosition() const {
+	double x, y;
+	glfwGetCursorPos(handle, &x, &y);
+
+	return {x, y};
+}
+
+/*
  * Window
  */
 
@@ -45,7 +68,7 @@ void Window::glfwKeyCallback(GLFWwindow* glfw_window, int key, int scancode, int
 	auto* window = (Window*) glfwGetWindowUserPointer(glfw_window);
 
 	if (window) {
-		glm::vec2 mouse = window->getCursor();
+		glm::vec2 mouse = window->getInputContext().getCursorPosition();
 		window->getInputDispatcher().onEvent(KeyboardEvent {key, scancode, action, mods, mouse.x, mouse.y});
 	}
 }
@@ -54,7 +77,7 @@ void Window::glfwButtonCallback(GLFWwindow* glfw_window, int button, int action,
 	auto* window = (Window*) glfwGetWindowUserPointer(glfw_window);
 
 	if (window) {
-		glm::vec2 mouse = window->getCursor();
+		glm::vec2 mouse = window->getInputContext().getCursorPosition();
 		window->getInputDispatcher().onEvent(ButtonEvent {button, action, mods, mouse.x, mouse.y});
 	}
 }
@@ -63,7 +86,7 @@ void Window::glfwScrollCallback(GLFWwindow* glfw_window, double horizontal, doub
 	auto* window = (Window*) glfwGetWindowUserPointer(glfw_window);
 
 	if (window) {
-		glm::vec2 mouse = window->getCursor();
+		glm::vec2 mouse = window->getInputContext().getCursorPosition();
 		window->getInputDispatcher().onEvent(ScrollEvent {horizontal, vertical, mouse.x, mouse.y});
 	}
 }
@@ -74,9 +97,6 @@ void Window::glfwCursorCallback(GLFWwindow* glfw_window, double x, double y) {
 	if (window) {
 		MouseEvent event {x, y};
 		window->getInputDispatcher().onEvent(event);
-
-		// update mouse capture state
-		window->setMouseCapture(event.capture_flag);
 	}
 }
 
@@ -84,7 +104,7 @@ void Window::glfwUnicodeCallback(GLFWwindow* glfw_window, unsigned int unicode) 
 	auto* window = (Window*) glfwGetWindowUserPointer(glfw_window);
 
 	if (window) {
-		glm::vec2 mouse = window->getCursor();
+		glm::vec2 mouse = window->getInputContext().getCursorPosition();
 		window->getInputDispatcher().onEvent(UnicodeEvent {unicode, mouse.x, mouse.y});
 	}
 }
@@ -148,8 +168,14 @@ GLFWwindow* Window::getHandle() const {
 	return handle;
 }
 
-void Window::poll() const {
+void Window::poll() {
 	glfwPollEvents();
+
+	FrameEvent event {};
+	dispatcher.onEvent(event);
+
+	setMouseCapture(event.capture_flag);
+	setShouldClose(event.close_flag);
 }
 
 bool Window::shouldClose() const {
@@ -164,19 +190,8 @@ InputDispatcher& Window::getInputDispatcher() {
 	return dispatcher;
 }
 
-bool Window::isKeyPressed(int key) const {
-	return glfwGetKey(handle, key) == GLFW_PRESS;
-}
-
-bool Window::isButtonPressed(int button) const {
-	return glfwGetMouseButton(handle, button) == GLFW_PRESS;
-}
-
-glm::vec2 Window::getCursor() const {
-	double x, y;
-	glfwGetCursorPos(handle, &x, &y);
-
-	return {x, y};
+InputContext Window::getInputContext() {
+	return {*this};
 }
 
 void Window::setMouseCapture(bool capture) {
@@ -184,5 +199,13 @@ void Window::setMouseCapture(bool capture) {
 		this->capture = capture;
 
 		glfwSetInputMode(handle, GLFW_CURSOR, capture ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL);
+	}
+}
+
+void Window::setShouldClose(bool close) {
+	if (close != this->close) {
+		this->close = close;
+
+		glfwSetWindowShouldClose(handle, close);
 	}
 }

--- a/src/render/window.cpp
+++ b/src/render/window.cpp
@@ -93,8 +93,7 @@ void Window::glfwWindowCloseCallback(GLFWwindow* glfw_window) {
 	auto* window = (Window*) glfwGetWindowUserPointer(glfw_window);
 
 	if (window) {
-		glm::vec2 mouse = window->getCursor();
-		CloseEvent event {mouse.x, mouse.y};
+		CloseEvent event {};
 		window->getInputDispatcher().onEvent(event);
 
 		glfwSetWindowShouldClose(glfw_window, !event.abort_flag);
@@ -105,8 +104,7 @@ void Window::glfwWindowResizeCallback(GLFWwindow* glfw_window, int width, int he
 	auto* window = (Window*) glfwGetWindowUserPointer(glfw_window);
 
 	if (window) {
-		glm::vec2 mouse = window->getCursor();
-		window->getInputDispatcher().onEvent(ResizeEvent {width, height, mouse.x, mouse.y});
+		window->getInputDispatcher().onEvent(ResizeEvent {width, height});
 	}
 }
 

--- a/src/render/window.hpp
+++ b/src/render/window.hpp
@@ -21,12 +21,31 @@ class WindowSystem {
 
 };
 
+class InputContext {
+
+	private:
+
+		friend class Window;
+		GLFWwindow* handle;
+
+		InputContext(const Window& window);
+
+	public:
+
+		bool isKeyPressed(int key) const;
+		bool isButtonPressed(int button) const;
+		glm::vec2 getCursorPosition() const;
+
+
+};
 
 class Window {
 
 	private:
 
 		bool capture = false;
+		bool close = false;
+
 		InputDispatcher dispatcher;
 		GLFWwindow* handle;
 
@@ -41,21 +60,21 @@ class Window {
 
 		friend class WindowSystem;
 		Window(uint32_t w, uint32_t h, std::string title);
+
+		// Controlled using FrameEvent
 		void setMouseCapture(bool capture);
+		void setShouldClose(bool close);
 
 	public:
 
 		~Window();
 
 		GLFWwindow* getHandle() const;
-		void poll() const;
+		void poll();
 		bool shouldClose() const;
 		void getFramebufferSize(int* width, int* height) const;
 
 		InputDispatcher& getInputDispatcher();
-
-		bool isKeyPressed(int key) const;
-		bool isButtonPressed(int button) const;
-		glm::vec2 getCursor() const;
+		InputContext getInputContext();
 
 };

--- a/src/shared/weighed.hpp
+++ b/src/shared/weighed.hpp
@@ -18,7 +18,7 @@ class WeighedSet {
 			}
 		};
 
-		using Set = std::set<Node, Order>;
+		using Set = std::multiset<Node, Order>;
 		Set set;
 
 	public:

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -105,3 +105,26 @@ TEST(util_weighed_set_limit) {
 	CHECK(set.highest(), 20);
 
 };
+
+TEST(util_weighed_set_repeated) {
+
+	WeighedSet<int, std::greater<>> set;
+
+	set.insert(20, 111);
+	set.insert(10, 132);
+	set.insert(10, 321);
+	set.insert(10, 213);
+
+	CHECK(set.size(), 4);
+	int sum = 0;
+
+	for (auto& i : set) {
+		sum += i;
+	}
+
+	CHECK(sum, 777);
+	set.remove(321);
+
+	CHECK(set.size(), 3);
+
+};


### PR DESCRIPTION
## Input System v3
Fixed some bugs introduced in v2 as well as an improved capture method based on `FrameEvent`

### Changes
- Added `FrameEvent` (sent every frame), this event is responsible for deciding which listener has "window control permission" - that is - the right to capture the mouse (using `FrameEvent::capture()`) and close the window (using `FrameEvent::close()`)
- Event are now split into positioned and position-less, `CloseEvent`, `FrameEvent`, and `ResizeEvent` do not carry the mouse position information anymore.
- Added vectorized `glm::vec2` getters for mouse position (on positioned events, `getMouse()`) and scroll
- Fixed priority and VSTL issues