### PR TITLE
Multisampling

### DIFF
--- a/src/external.hpp
+++ b/src/external.hpp
@@ -24,6 +24,7 @@
 #include <filesystem>
 #include <utility>
 #include <thread>
+#include <array>
 
 // GLFW
 #define GLFW_INCLUDE_VULKAN

--- a/src/render/asset/atlas.cpp
+++ b/src/render/asset/atlas.cpp
@@ -72,13 +72,13 @@ ImageData & DynamicAtlas::getImage() {
 	return atlas;
 }
 
-Sprite DynamicAtlas::submit(ImageData& image) {
+Sprite DynamicAtlas::submitWithMargin(ImageData& image) {
 	rewrite = true;
-	ImageData extended = image.expand(1, ImageExpand::COPY_BORDER);
+
+	ImageData extended = image.expand(4);
 	Sprite sprite = packSprite(extended);
 	extended.close();
-
-	return sprite.shrink(1);
+	return sprite.shrink(4);
 }
 
 bool DynamicAtlas::upload(CommandRecorder& recorder) {
@@ -116,7 +116,7 @@ DynamicImageAtlas::DynamicImageAtlas(const std::shared_ptr<DynamicAtlas>& atlas)
 
 	ImageData blank = ImageData::allocate(16, 16);
 	blank.clear({255, 255, 255, 255});
-	sprites[BLANK_SPRITE] = atlas->submit(blank);
+	sprites[BLANK_SPRITE] = atlas->submitWithMargin(blank);
 	blank.close();
 
 }
@@ -129,7 +129,7 @@ Sprite DynamicImageAtlas::getOrLoad(const std::string& path) {
 	}
 
 	ImageData data = ImageData::loadFromFile(path, 4);
-	Sprite sprite = atlas->submit(data);
+	Sprite sprite = atlas->submitWithMargin(data);
 	data.close();
 
 	sprites[path] = sprite;

--- a/src/render/asset/atlas.hpp
+++ b/src/render/asset/atlas.hpp
@@ -32,8 +32,8 @@ class DynamicAtlas {
 		/// Get the image data containing all submitted images
 		ImageData& getImage();
 
-		/// Add image to atlas and return its coordinates
-		Sprite submit(ImageData& image);
+		/// Add image (with margin) to atlas and return its coordinates
+		Sprite submitWithMargin(ImageData& image);
 
 		/// Upload (or recreate) underlying vulkan texture
 		bool upload(CommandRecorder& recorder);

--- a/src/render/asset/font.cpp
+++ b/src/render/asset/font.cpp
@@ -76,7 +76,7 @@ bool Font::loadUnicode(uint32_t unicode, float scale, float range) {
 			}
 		}
 
-		Sprite sprite = atlas->submit(image);
+		Sprite sprite = atlas->submitWithMargin(image);
 		image.close();
 
 		info.x0 = sprite.u1;

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -379,7 +379,7 @@ void Renderer::createAttachments() {
 		.setFormat(surface_format)
 		.setAspect(VK_IMAGE_ASPECT_COLOR_BIT)
 		.setUsage(VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
-		.setClearColor(3 / 255.0f, 169 / 255.0f, 252 / 255.0f, 1.0f)
+		.setClearColor(0.0f, 0.0f, 0.0f, 1.0f)
 		.setSampleCount(VK_SAMPLE_COUNT_8_BIT)
 		.setDebugName("Color MSAA")
 		.createAttachment();
@@ -417,7 +417,7 @@ void Renderer::createRenderPasses() {
 		RenderPassBuilder builder;
 
 		Attachment::Ref color = builder.addAttachment(attachment_color_msaa)
-			.begin(ColorOp::CLEAR, VK_IMAGE_LAYOUT_UNDEFINED)
+			.begin(ColorOp::LOAD, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
 			.end(ColorOp::STORE, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
 			.next();
 
@@ -427,7 +427,7 @@ void Renderer::createRenderPasses() {
 			.next();
 
 		Attachment::Ref screen = builder.addAttachment(attachment_screen)
-			.begin(ColorOp::LOAD, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
+			.begin(ColorOp::CLEAR, VK_IMAGE_LAYOUT_UNDEFINED)
 			.end(ColorOp::STORE, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)
 			.next();
 
@@ -455,12 +455,12 @@ void Renderer::createRenderPasses() {
 
 		RenderPassBuilder builder;
 
-		Attachment::Ref color = builder.addAttachment(attachment_screen)
+		Attachment::Ref color = builder.addAttachment(attachment_color_msaa)
 			.begin(ColorOp::CLEAR, VK_IMAGE_LAYOUT_UNDEFINED)
 			.end(ColorOp::STORE, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
 			.next();
 
-		Attachment::Ref depth = builder.addAttachment(attachment_depth)
+		Attachment::Ref depth = builder.addAttachment(attachment_depth_msaa)
 			.begin(ColorOp::CLEAR, VK_IMAGE_LAYOUT_UNDEFINED)
 			.end(ColorOp::STORE, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
 			.next();

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -380,7 +380,7 @@ void Renderer::createAttachments() {
 		.setAspect(VK_IMAGE_ASPECT_COLOR_BIT)
 		.setUsage(VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
 		.setClearColor(0.0f, 0.0f, 0.0f, 1.0f)
-		.setSampleCount(VK_SAMPLE_COUNT_8_BIT)
+		.setSampleCount(msaa)
 		.setDebugName("Color MSAA")
 		.createAttachment();
 
@@ -389,7 +389,7 @@ void Renderer::createAttachments() {
 		.setAspect(VK_IMAGE_ASPECT_DEPTH_BIT)
 		.setClearDepth(1.0f)
 		.setUsage(VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
-		.setSampleCount(VK_SAMPLE_COUNT_8_BIT)
+		.setSampleCount(msaa)
 		.setDebugName("Depth MSAA")
 		.createAttachment();
 
@@ -613,9 +613,6 @@ void Renderer::lateClose() {
 }
 
 void Renderer::lateInit() {
-	// msaa is what will be really used for rendering
-	// change the getSampleCount argument to control intend
-	msaa = physical->getSampleCount(VK_SAMPLE_COUNT_8_BIT);
 
 	createSwapchain();
 	createPipelines();
@@ -765,6 +762,10 @@ Renderer::Renderer(ApplicationParameters& parameters)
 
 	// render pass used during mesh rendering
 	mesh_constant = createPushConstant(VK_SHADER_STAGE_VERTEX_BIT, sizeof(MeshConstant));
+
+	// msaa is what will be really used for rendering
+	// change the getSampleCount argument to control intend
+	msaa = physical->getSampleCount(VK_SAMPLE_COUNT_8_BIT);
 
 	createAttachments();
 	createRenderPasses();

--- a/src/render/renderer.hpp
+++ b/src/render/renderer.hpp
@@ -94,8 +94,10 @@ class Renderer {
 		Shader shader_blit_fragment;
 
 		// attachments
-		Attachment attachment_color;
+		Attachment attachment_screen;
 		Attachment attachment_depth;
+		Attachment attachment_color_msaa;
+		Attachment attachment_depth_msaa;
 		Attachment attachment_albedo;
 
 		// descriptors
@@ -125,6 +127,9 @@ class Renderer {
 
 		// push constants
 		PushConstant mesh_constant;
+
+		// current multisampling anti-aliasing setting
+		VkSampleCountFlagBits msaa;
 
 	private:
 

--- a/src/render/vulkan/buffer/attachment.cpp
+++ b/src/render/vulkan/buffer/attachment.cpp
@@ -41,6 +41,10 @@ VkImageAspectFlags Attachment::getAspect() const {
 	return settings.view_info.subresourceRange.aspectMask;
 }
 
+VkSampleCountFlagBits Attachment::getSamples() const {
+	return settings.vk_samples;
+}
+
 const Texture& Attachment::getTexture() const {
 	return texture;
 }
@@ -53,8 +57,8 @@ void Attachment::markSwapchainBacked(){
 	magicity = true;
 }
 
-void Attachment::allocate(LogicalDevice& device, int width, int height, Allocator& allocator) {
-	Image image = allocator.allocateImage(Memory::DEVICE, width, height, getFormat(), settings.vk_usage, 1, 1, settings.debug_name.c_str());
+void Attachment::allocate(LogicalDevice& device, VkExtent2D extent, Allocator& allocator) {
+	Image image = allocator.allocateImage(Memory::DEVICE, extent.width, extent.height, getFormat(), settings.vk_usage, 1, 1, settings.vk_samples, settings.debug_name.c_str());
 	texture = settings.buildTexture(device, image);
 }
 

--- a/src/render/vulkan/buffer/attachment.hpp
+++ b/src/render/vulkan/buffer/attachment.hpp
@@ -53,6 +53,9 @@ class Attachment {
 		/// Get the aspect flags of this attachment
 		VkImageAspectFlags getAspect() const;
 
+		/// Get per-pixel sample count of this image
+		VkSampleCountFlagBits getSamples() const;
+
 		/// Get the underlying texture, use only after a call to allocate()
 		const Texture& getTexture() const;
 
@@ -63,7 +66,7 @@ class Attachment {
 		void markSwapchainBacked();
 
 		/// Create the underlying texture
-		void allocate(LogicalDevice& device, int width, int height, Allocator& allocator);
+		void allocate(LogicalDevice& device, VkExtent2D extent, Allocator& allocator);
 
 		/// Close the underlying texture
 		void close(LogicalDevice device);

--- a/src/render/vulkan/buffer/image.cpp
+++ b/src/render/vulkan/buffer/image.cpp
@@ -338,7 +338,7 @@ MutableImage ManagedImageDataSet::upload(Allocator& allocator, CommandRecorder& 
 	}
 
 	Buffer staging = allocator.allocateBuffer(Memory::STAGED, total, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, "Image Staging");
-	Image image = allocator.allocateImage(Memory::DEVICE, layer_width, layer_height, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, layer_count, levels(), "Untitled");
+	Image image = allocator.allocateImage(Memory::DEVICE, layer_width, layer_height, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, layer_count, levels(), VK_SAMPLE_COUNT_1_BIT, "Untitled");
 
 	MutableImage uploader {staging, image};
 	int level = 0;

--- a/src/render/vulkan/buffer/image.cpp
+++ b/src/render/vulkan/buffer/image.cpp
@@ -96,7 +96,7 @@ void ImageData::save(const std::string& path) const {
 	}
 }
 
-ImageData ImageData::expand(int margin, ImageExpand mode) {
+ImageData ImageData::expand(int margin) {
 	if (margin < 0) {
 		throw std::runtime_error {"Invalid image margin!"};
 	}
@@ -109,25 +109,21 @@ ImageData ImageData::expand(int margin, ImageExpand mode) {
 		return result;
 	}
 
-	if (mode == ImageExpand::COPY_BORDER) {
+	for (int i = 1; i <= margin; i ++) {
 
-		for (int i = 1; i <= margin; i ++) {
+		int start = margin - i;
+		int end = margin + i;
+		int last = end - 1;
 
-			int start = margin - i;
-			int end = margin + i;
-			int last = end - 1;
-
-			for (int y = start; y < (h + end); y ++) {
-				memcpy(result.pixel(start, y), result.pixel(start + 1, y), channels());
-				memcpy(result.pixel(w + last, y), result.pixel(w + last - 1, y), channels());
-			}
-
-			for (int x = start; x < (w + end); x ++) {
-				memcpy(result.pixel(x, start), result.pixel(x, start + 1), channels());
-				memcpy(result.pixel(x, h + last), result.pixel(x, h + last - 1), channels());
-			}
+		for (int y = start; y < (h + end); y ++) {
+			memcpy(result.pixel(start, y), result.pixel(start + 1, y), channels());
+			memcpy(result.pixel(w + last, y), result.pixel(w + last - 1, y), channels());
 		}
 
+		for (int x = start; x < (w + end); x ++) {
+			memcpy(result.pixel(x, start), result.pixel(x, start + 1), channels());
+			memcpy(result.pixel(x, h + last), result.pixel(x, h + last - 1), channels());
+		}
 	}
 
 	return result;

--- a/src/render/vulkan/buffer/image.hpp
+++ b/src/render/vulkan/buffer/image.hpp
@@ -11,11 +11,6 @@ enum struct ImageScaling {
 	NEAREST
 };
 
-enum struct ImageExpand {
-	UNDEFINED,
-	COPY_BORDER,
-};
-
 class MutableImage;
 class Image;
 
@@ -89,7 +84,7 @@ class ImageData {
 		 * Creates an image copy expanded in every direction by given number of pixels,
 		 * the new pixels are filled according to the given mode
 		 */
-		ImageData expand(int margin, ImageExpand mode);
+		ImageData expand(int margin);
 
 		/**
 		 * Returns an image data buffer for the image pointed to by the

--- a/src/render/vulkan/buffer/texture.cpp
+++ b/src/render/vulkan/buffer/texture.cpp
@@ -61,8 +61,8 @@ void TextureDelegate::checkImageFormat(VkFormat provided) const {
 	}
 }
 
-TextureDelegate::TextureDelegate(VkImageUsageFlags usage, VkClearValue clear, VkImageViewCreateInfo view, VkSamplerCreateInfo sampler, const std::string& debug_name)
-: debug_name(debug_name), vk_usage(usage), vk_clear(clear), view_info(view), sampler_info(sampler) {}
+TextureDelegate::TextureDelegate(VkImageUsageFlags usage, VkClearValue clear, VkImageViewCreateInfo view, VkSamplerCreateInfo sampler, VkSampleCountFlagBits samples, const std::string& debug_name)
+: debug_name(debug_name), vk_usage(usage), vk_clear(clear), view_info(view), sampler_info(sampler), vk_samples(samples) {}
 
 Texture TextureDelegate::buildTexture(LogicalDevice& device, const Image& image) const {
 
@@ -194,13 +194,18 @@ TextureBuilder& TextureBuilder::setFormat(VkFormat format) {
 	return *this;
 }
 
+TextureBuilder& TextureBuilder::setSampleCount(VkSampleCountFlagBits samples) {
+	vk_samples = samples;
+	return *this;
+}
+
 TextureBuilder& TextureBuilder::setUsage(VkImageUsageFlags usage) {
 	vk_usage = usage;
 	return *this;
 }
 
 TextureDelegate TextureBuilder::createDelegate() const {
-	return {vk_usage, vk_clear, view_info, sampler_info, debug_name};
+	return {vk_usage, vk_clear, view_info, sampler_info, vk_samples, debug_name};
 }
 
 Texture TextureBuilder::createTexture(LogicalDevice& device, const Image& image) const {

--- a/src/render/vulkan/buffer/texture.hpp
+++ b/src/render/vulkan/buffer/texture.hpp
@@ -41,6 +41,7 @@ class TextureDelegate {
 		VkClearValue vk_clear {};
 		VkImageViewCreateInfo view_info {};
 		VkSamplerCreateInfo sampler_info {};
+		VkSampleCountFlagBits vk_samples;
 
 		friend class TextureBuilder;
 		friend class Attachment;
@@ -50,7 +51,7 @@ class TextureDelegate {
 	public:
 
 		TextureDelegate() = default;
-		TextureDelegate(VkImageUsageFlags usage, VkClearValue clear, VkImageViewCreateInfo view, VkSamplerCreateInfo sampler, const std::string& debug_name);
+		TextureDelegate(VkImageUsageFlags usage, VkClearValue clear, VkImageViewCreateInfo view, VkSamplerCreateInfo sampler, VkSampleCountFlagBits samples, const std::string& debug_name);
 
 		Texture buildTexture(LogicalDevice& device, const Image& image) const;
 		Attachment buildAttachment();
@@ -66,6 +67,7 @@ class TextureBuilder {
 		VkClearValue vk_clear {};
 		VkImageViewCreateInfo view_info {};
 		VkSamplerCreateInfo sampler_info {};
+		VkSampleCountFlagBits vk_samples = VK_SAMPLE_COUNT_1_BIT;
 
 	public:
 
@@ -110,6 +112,9 @@ class TextureBuilder {
 
 		/// Relevant for attachments only, set the expected image format
 		TextureBuilder& setFormat(VkFormat format);
+
+		/// Relevant for attachments only, set the per-pixel sample count
+		TextureBuilder& setSampleCount(VkSampleCountFlagBits samples);
 
 		/// Relevant for attachments only, set attachment image usage
 		TextureBuilder& setUsage(VkImageUsageFlags usage);

--- a/src/render/vulkan/pass/attachment.cpp
+++ b/src/render/vulkan/pass/attachment.cpp
@@ -24,10 +24,10 @@ AttachmentBuilder& AttachmentBuilder::output(VkAttachmentStoreOp color, VkAttach
 	return *this;
 }
 
-AttachmentBuilder::AttachmentBuilder(RenderPassBuilder& builder, const Attachment& attachment, VkSampleCountFlagBits samples)
+AttachmentBuilder::AttachmentBuilder(RenderPassBuilder& builder, const Attachment& attachment)
 : attachment(attachment), builder(builder) {
 	description.format = attachment.getFormat();
-	description.samples = samples;
+	description.samples = attachment.getSamples();
 }
 
 Attachment::Ref AttachmentBuilder::next() {

--- a/src/render/vulkan/pass/attachment.hpp
+++ b/src/render/vulkan/pass/attachment.hpp
@@ -22,7 +22,7 @@ class AttachmentBuilder {
 
 	public:
 
-		AttachmentBuilder(RenderPassBuilder& builder, const Attachment& attachment, VkSampleCountFlagBits samples);
+		AttachmentBuilder(RenderPassBuilder& builder, const Attachment& attachment);
 
 		/**
 		 * @brief Specify load operation.

--- a/src/render/vulkan/pass/graphics.cpp
+++ b/src/render/vulkan/pass/graphics.cpp
@@ -221,6 +221,7 @@ GraphicsPipelineBuilder& GraphicsPipelineBuilder::withRenderPass(RenderPass& ren
 	blending.attachmentCount = render_pass.getSubpass(subpass_index).getAttachmentCount();
 	vk_pass = render_pass.vk_pass;
 	subpass = subpass_index;
+	multisampling.rasterizationSamples = render_pass.samples;
 	return *this;
 }
 

--- a/src/render/vulkan/pass/render.hpp
+++ b/src/render/vulkan/pass/render.hpp
@@ -18,11 +18,12 @@ class RenderPass {
 		VkRenderPass vk_pass;
 		std::vector<VkClearValue> values;
 		std::vector<Subpass> subpasses;
+		VkSampleCountFlagBits samples;
 
 	public:
 
 		RenderPass() = default;
-		RenderPass(VkDevice vk_device, VkRenderPass vk_pass, std::vector<VkClearValue>& values, std::vector<Subpass>& subpass_info, FramebufferSet& framebuffer);
+		RenderPass(VkDevice vk_device, VkRenderPass vk_pass, std::vector<VkClearValue>& values, std::vector<Subpass>& subpass_info, FramebufferSet& framebuffer, VkSampleCountFlagBits count);
 
 		void close();
 		const Subpass& getSubpass(int subpass) const;
@@ -45,6 +46,7 @@ class RenderPassBuilder {
 	private:
 
 		FramebufferSet framebuffer;
+		VkSampleCountFlagBits count = VK_SAMPLE_COUNT_1_BIT;
 
 		std::vector<VkClearValue> values;
 		std::vector<AttachmentBuilder> attachments;
@@ -52,6 +54,8 @@ class RenderPassBuilder {
 		std::vector<DependencyBuilder> dependencies;
 
 		Pyramid<uint32_t> preserve;
+
+		void setSampleCount(VkSampleCountFlagBits samples);
 
 	public:
 
@@ -66,7 +70,7 @@ class RenderPassBuilder {
 		 * @brief Begin attachment creation
 		 * Adds and makes usable an attachment for subpasses in this RenderPass
 		 */
-		AttachmentBuilder addAttachment(const Attachment& attachment, VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT);
+		AttachmentBuilder addAttachment(const Attachment& attachment);
 
 		/**
 		 * @brief Begin subpass creation

--- a/src/render/vulkan/setup/allocator.cpp
+++ b/src/render/vulkan/setup/allocator.cpp
@@ -157,7 +157,7 @@ Buffer Allocator::allocateBuffer(Memory memory, size_t bytes, VkBufferUsageFlags
 	return {buffer, {vma_allocator, allocation}, bytes};
 }
 
-Image Allocator::allocateImage(Memory memory, int width, int height, VkFormat format, VkImageUsageFlags usage, int layers, int levels, const char* name) {
+Image Allocator::allocateImage(Memory memory, int width, int height, VkFormat format, VkImageUsageFlags usage, int layers, int levels, VkSampleCountFlagBits samples, const char* name) {
 	VmaAllocationCreateInfo allocation_info {};
 	fromMemoryGroup(&allocation_info, memory);
 
@@ -174,7 +174,7 @@ Image Allocator::allocateImage(Memory memory, int width, int height, VkFormat fo
 	create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 	create_info.usage = usage;
 	create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-	create_info.samples = VK_SAMPLE_COUNT_1_BIT;
+	create_info.samples = samples;
 	create_info.flags = 0;
 
 	VkImage image;

--- a/src/render/vulkan/setup/allocator.hpp
+++ b/src/render/vulkan/setup/allocator.hpp
@@ -110,7 +110,7 @@ class Allocator {
 		 * @param[in] levels Number om image mip-map levels
 		 * @param[in] name   (Optional) name for the buffer
 		 */
-		Image allocateImage(Memory memory, int width, int height, VkFormat format, VkImageUsageFlags usage, int layers, int levels, NULLABLE const char* name);
+		Image allocateImage(Memory memory, int width, int height, VkFormat format, VkImageUsageFlags usage, int layers, int levels, VkSampleCountFlagBits samples, NULLABLE const char* name);
 
 		/**
 		 * @brief Allocate raytracing acceleration structure of given size

--- a/src/render/vulkan/setup/device.cpp
+++ b/src/render/vulkan/setup/device.cpp
@@ -140,6 +140,45 @@ int PhysicalDevice::getMaxRaytraceRecursionDepth() const {
 	return ray_properties.maxRayRecursionDepth;
 }
 
+VkSampleCountFlagBits PhysicalDevice::getSampleCount(VkSampleCountFlagBits preferred) const {
+	const auto& limits = getLimits();
+	VkSampleCountFlags supported = limits.framebufferColorSampleCounts & limits.framebufferDepthSampleCounts;
+
+	// short-circuit in most cases
+	if (supported & preferred) {
+		return preferred;
+	}
+
+	std::array bits = {
+		VK_SAMPLE_COUNT_1_BIT,
+		VK_SAMPLE_COUNT_2_BIT,
+		VK_SAMPLE_COUNT_4_BIT,
+		VK_SAMPLE_COUNT_8_BIT,
+		VK_SAMPLE_COUNT_16_BIT,
+		VK_SAMPLE_COUNT_32_BIT,
+		VK_SAMPLE_COUNT_64_BIT,
+	};
+
+	auto it = std::find(bits.begin(), bits.end(), preferred);
+
+	if (it == bits.end()) {
+		printf("ERROR: Failed to find preferred sample count in internal array!\n");
+		return VK_SAMPLE_COUNT_1_BIT;
+	}
+
+	while (it != bits.begin()) {
+		if (supported & *it) {
+			return *it;
+		}
+
+		it --;
+	}
+
+	printf("WARN: Multisampling not supported on selected device!\n");
+	return VK_SAMPLE_COUNT_1_BIT;
+}
+
+
 /*
  * Logical Device
  */

--- a/src/render/vulkan/setup/device.hpp
+++ b/src/render/vulkan/setup/device.hpp
@@ -47,59 +47,63 @@ class PhysicalDevice {
 		const char* getName() const;
 
 		/**
-		 * @brief Check if the device's swap chain is compatible with our window surface,
-		 *        we will consider it compatible if at least one image format and presentation mode match
+		 * Check if the device's swap chain is compatible with our window surface,
+		 * we will consider it compatible if at least one image format and presentation mode match
 		 *
-		 * @param surface the window surface to check compatibility with
+		 * @param[in] surface the window surface to check compatibility with
 		 */
 		bool canUseSurface(VkSurfaceKHR surface) const;
 
 		/**
-		 * @brief Get the underlying vulkan object handle
-		 * @note  Try to avoid using this function when possible
+		 * Get the underlying vulkan object handle
 		 */
 		VkPhysicalDevice getHandle() const;
 
 		/**
-		 * @brief Get the list of extensions supported by this device
+		 * Get the list of extensions supported by this device
 		 */
 		bool hasExtension(const char* name) const;
 
 		/**
-		 * @brief Get the list of queue families supported by this device
+		 * Get the list of queue families supported by this device
 		 */
 		std::vector<Family> getFamilies() const;
 
 		/**
-		 * @brief Get information about supported swapchain configurations
+		 * Get information about supported swapchain configurations
 		 */
 		SwapchainInfo getSwapchainInfo(VkSurfaceKHR surface);
 
 		/**
-		 * @brief Get the cached device properties
+		 * Get the cached device properties
 		 */
 		const VkPhysicalDeviceProperties& getProperties() const;
 
 		/**
-		 * @brief Get the cached device limits
+		 * Get the cached device limits
 		 */
 		const VkPhysicalDeviceLimits& getLimits() const;
 
 		/**
-		 * @brief Get the cached device feature chain entry
+		 * Get the cached device feature chain entry
 		 */
 		const void* getFeatures(VkStructureType type) const;
 
 		/**
-		 * @brief Get the cached device properties chain entry
+		 * Get the cached device properties chain entry
 		 */
 		const void* getProperties(VkStructureType type) const;
 
 		/**
-		 * @brief Get the device's maximal ray invocation recursion
-		 *        depth, learn more in @see RaytracePipelineBuilder::withRecursionDepth()
+		 * Get the device's maximal ray invocation recursion
+		 * depth, learn more in @see RaytracePipelineBuilder::withRecursionDepth()
 		 */
 		int getMaxRaytraceRecursionDepth() const;
+
+		/**
+		 * Get the supported sampling count that is the closest to the preferred value
+		 */
+		VkSampleCountFlagBits getSampleCount(VkSampleCountFlagBits preferred) const;
 
 };
 


### PR DESCRIPTION
Added MSAA for GUI elements and the underlying Vulkan abstraction

To add multi-sampling simply specify the sample count on a attachment and add that attachment to a render pass, then, when you finish multisampled-rendering [resolve](https://stackoverflow.com/questions/64091506/what-is-a-resolve-attachment) the attachment into a normal screen (or some other color) attachment by adding the target attachment to a subpass as a resolve attachment (see `SubpassBuilder::addResolve()`).

A supported sample count can be obtained from a physical device using `PhysicalDevice::getSampleCount(VkSampleCountFlagBits preferred)`, this method will print a warning if no sampling (other that the default 1) is supported by the device so don't call it in a loop.