### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.obj binary


### PR DESCRIPTION
Don't show `.obj` files in diffs, if some other file type should also be ignored please just commit it onto here.
`.mtl` files where not included as they are shorter and more config-like.